### PR TITLE
Fix typos and grammar

### DIFF
--- a/docs/m4t/on_device_README.md
+++ b/docs/m4t/on_device_README.md
@@ -34,7 +34,7 @@ Also running the exported model doesn't need python runtime. For example, you co
 
 ## Metrics
 ### S2TT BLEU / S2ST ASR-BLEU on FLEURS
-For ASR-BLEU, we follow the same protocol as Whisper Large/Medium models: We used Whisper-large-v2 for Eng-X and Whisper-medium for X-Eng when evaluating ASR BLEU.
+For ASR-BLEU, we follow the same protocol as SeamlessM4T models: We used Whisper-large-v2 for Eng-X and Whisper-medium for X-Eng when evaluating ASR BLEU.
 | Direction  | 1st-pass BLEU (S2TT) | 2nd-pass ASR-BLEU (S2ST)
 |---------|----------------------|----------------------|
 | eng-hin|10.43|15.06|

--- a/docs/m4t/on_device_README.md
+++ b/docs/m4t/on_device_README.md
@@ -34,7 +34,7 @@ Also running the exported model doesn't need python runtime. For example, you co
 
 ## Metrics
 ### S2TT BLEU / S2ST ASR-BLEU on FLEURS
-For ASR-BLEU, we follow the same protocal as Large/Medium models: Use Whisper-large-v2 for eng-X and Whisper-medium for X-eng when evaluating ASR BLEU.
+For ASR-BLEU, we follow the same protocol as Whisper Large/Medium models: We used Whisper-large-v2 for Eng-X and Whisper-medium for X-Eng when evaluating ASR BLEU.
 | Direction  | 1st-pass BLEU (S2TT) | 2nd-pass ASR-BLEU (S2ST)
 |---------|----------------------|----------------------|
 | eng-hin|10.43|15.06|

--- a/docs/m4t/on_device_README.md
+++ b/docs/m4t/on_device_README.md
@@ -34,7 +34,7 @@ Also running the exported model doesn't need python runtime. For example, you co
 
 ## Metrics
 ### S2TT BLEU / S2ST ASR-BLEU on FLEURS
-For ASR-BLEU, we follow the same protocol as SeamlessM4T models: We used Whisper-large-v2 for Eng-X and Whisper-medium for X-Eng when evaluating ASR BLEU.
+For ASR-BLEU, we follow the same protocol as SeamlessM4T Large/Medium models: We used Whisper-large-v2 for Eng-X and Whisper-medium for X-Eng when evaluating ASR BLEU.
 | Direction  | 1st-pass BLEU (S2TT) | 2nd-pass ASR-BLEU (S2ST)
 |---------|----------------------|----------------------|
 | eng-hin|10.43|15.06|


### PR DESCRIPTION
1. Fixed spelling of "protocol"
2. Rephrased the sentence to make it clear that the protocol is similar to what Whisper used for evaluation