### PR TITLE
Re-enable unit extraction in dataset preparation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,4 +143,6 @@ outputs
 
 # symlinks
 seamless_communication
+# ignore src/seamless_communication  
+!*/seamless_communication
 m4t_scripts


### PR DESCRIPTION
After https://github.com/facebookresearch/seamless_communication/pull/17 we can restore unit extraction in dataset preparation scripts

Tests:

```
python scripts/m4t/finetune/dataset.py --source_lang eng --target_lang kor --split validation --save_dir ~/dataset
```
Checked units of one sample from the generated dataset. Using vocoder and whisper produced an audio and its transcription: 
Original audio text: `이 역동적인 수송 셔틀은 어떤 식으로든 모든 사람들이 자가용을 기반으로 하는 수송 시스템과 연결되고 이를 지원하도록 한다`
Transcription of the audio, generated from the units: `이 역동적인 수송 셔틀은 어떤 식으로든 모든 사람들이 자가용을 기반으로 하는 수송 시스템과 연결되고 이를 지원하도록 한다.
`

