### PR TITLE
Add max_len args in Translator

### DIFF
--- a/src/seamless_communication/models/inference/translator.py
+++ b/src/seamless_communication/models/inference/translator.py
@@ -116,12 +116,10 @@ class Translator(nn.Module):
                 unit_max_len_a = 1
 
         text_opts = SequenceGeneratorOptions(
-            beam_size=5,
-            soft_max_seq_len=(text_max_len_a, text_max_len_b)
+            beam_size=5, soft_max_seq_len=(text_max_len_a, text_max_len_b)
         )
         unit_opts = SequenceGeneratorOptions(
-            beam_size=5,
-            soft_max_seq_len=(unit_max_len_a, unit_max_len_b or 50)
+            beam_size=5, soft_max_seq_len=(unit_max_len_a, unit_max_len_b or 50)
         )
 
         if ngram_filtering:


### PR DESCRIPTION
Adding `max_len_a`and `max_len_b` for text/unit as arguments to `Translator`'s `predict`