### PR TITLE
Add audio_to_units in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     name="seamless_communication",
     version="1.0.0",
     packages=find_packages(where="src")
-    + ["m4t_scripts.finetune", "m4t_scripts.predict"],
+    + ["m4t_scripts.finetune", "m4t_scripts.predict", "m4t_scripts.audio_to_units"],
     package_dir={
         "m4t_scripts": "scripts/m4t",
         "seamless_communication": "src/seamless_communication",


### PR DESCRIPTION
`audio_to_units` was missing from installed package in `setup.py`, resulting in an error when calling `m4t_audio_to_units`