### PR TITLE
ggml : update cmake to build on macOS

### DIFF
--- a/ggml/README.md
+++ b/ggml/README.md
@@ -11,7 +11,8 @@ To build the interactive console for S2TT & ASR,
 
 cd seamless_communication/ggml
 mkdir build; cd build
-cmake -DGGML_OPENBLAS=ON \
+cmake \
+    -DGGML_OPENBLAS=ON \
     -DBUILD_SHARED_LIBS=On \
 	  -DCMAKE_BUILD_TYPE=Release \
 	  -DCMAKE_CXX_FLAGS="-g2 -fno-omit-frame-pointer" \
@@ -19,6 +20,8 @@ cmake -DGGML_OPENBLAS=ON \
 make -j4 unity # Interactive Console
 
 ```
+Note that `-DGGML_OPENBLAS=ON` is not necessary on macOS.
+
 For more build commands see [Makefile](Makefile). 
 
 ## CLI usage

--- a/ggml/examples/common.h
+++ b/ggml/examples/common.h
@@ -37,11 +37,7 @@ struct gpt_params {
     int32_t n_gpu_layers     = 0;
 };
 
-bool unity_params_parse(int argc, char ** argv, unity_params & params);
-
 bool gpt_params_parse(int argc, char ** argv, gpt_params & params);
-
-void unity_print_usage(int /*argc*/, char ** argv, const unity_params & params);
 
 void gpt_print_usage(int argc, char ** argv, const gpt_params & params);
 

--- a/ggml/examples/unity/CMakeLists.txt
+++ b/ggml/examples/unity/CMakeLists.txt
@@ -9,9 +9,8 @@ target_sources(fairseq2_cpp
 )
 add_executable(unity unity.cpp)
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(SNDFILE REQUIRED sndfile)
-target_include_directories(unity PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../.. ${SNDFILE_INCLUDE_DIRS})
-target_link_libraries(unity PRIVATE ggml ${SNDFILE_LIBRARIES})
+pkg_check_modules(SNDFILE REQUIRED IMPORTED_TARGET sndfile)
+target_link_libraries(unity PRIVATE ggml PkgConfig::SNDFILE)
 target_sources(unity
     PRIVATE
         fairseq2.cpp


### PR DESCRIPTION
- Fix `pkg-config` import of `sndfile`. Tested on macOS and Ubuntu
- Remove `unity_params_parse` and `unity_print_usage ` declarations from `common` for now

```bash
$ ▶ ./bin/unity -m seamlessM4T_medium.ggml
little-endian
open_ggml_file: loading model from 'seamlessM4T_medium.ggml'
load_model_weights: model size:  6542.93 MB, memory used:  6543.31 MB, memory reserved:  6543.31 MB

Enter audio_path and tgt_lang, separated by space (or 'exit' to quit):
jfk.wav eng
Translating (Transcribing) jfk.wav to eng
So, my fellow Americans, don't ask what your country can do for you, ask what you can do for your country.

Enter audio_path and tgt_lang, separated by space (or 'exit' to quit):
```