### PR TITLE
[demo] m4tv2: fix snapshot path to use public repo

### DIFF
--- a/demo/m4tv2/app.py
+++ b/demo/m4tv2/app.py
@@ -30,7 +30,7 @@ from lang_list import (
 
 CHECKPOINTS_PATH = pathlib.Path(os.getenv("CHECKPOINTS_PATH", "/home/user/app/models"))
 if not CHECKPOINTS_PATH.exists():
-    snapshot_download(repo_id="meta-private/M4Tv2", repo_type="model", local_dir=CHECKPOINTS_PATH)
+    snapshot_download(repo_id="facebook/seamless-m4t-v2-large", repo_type="model", local_dir=CHECKPOINTS_PATH)
 asset_store.env_resolvers.clear()
 asset_store.env_resolvers.append(lambda: "demo")
 demo_metadata = [


### PR DESCRIPTION
Summary: the gradio demo currently uses the meta-private repo for the snapshot weights, this fixes it to use the public URL

Test Plan: ran python app.py and it successfully downloads the weights

Reviewers:

Subscribers:

Tasks:

Tags: accept2ship