### PR TITLE
[demo] m4tv2: fix checkpoint download path

### DIFF
--- a/demo/m4tv2/app.py
+++ b/demo/m4tv2/app.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import pathlib
+import getpass
 
 import gradio as gr
 import numpy as np
@@ -28,7 +29,8 @@ from lang_list import (
     TEXT_SOURCE_LANGUAGE_NAMES,
 )
 
-CHECKPOINTS_PATH = pathlib.Path(os.getenv("CHECKPOINTS_PATH", "/home/user/app/models"))
+user = getpass.getuser() # this is not portable on windows
+CHECKPOINTS_PATH = pathlib.Path(os.getenv("CHECKPOINTS_PATH", f"/home/{user}/app/models"))
 if not CHECKPOINTS_PATH.exists():
     snapshot_download(repo_id="meta-private/M4Tv2", repo_type="model", local_dir=CHECKPOINTS_PATH)
 asset_store.env_resolvers.clear()


### PR DESCRIPTION
Summary: /home/user/app/models is not a valid path in general. instead, we pull the current logged-in user from getpass.getuser() and interpolate the username into the path.

Test Plan: ran python app.py and was able to boot the demo successfully

Reviewers:

Subscribers:

Tasks:

Tags: accept2ship