### PR TITLE
Move Transformers section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ SeamlessM4T models support the tasks of:
 
 To learn more about the collection of SeamlessM4T models, the approach used in each, their language coverage and their performance, visit the [SeamlessM4T README](docs/m4t/README.md) or [🤗 Model Card](https://huggingface.co/facebook/seamless-m4t-v2-large).
 
+> [!NOTE]
+> Seamless M4T is also available in the 🤗 Transformers library. For more details, refer to the [SeamlessM4T docs](https://huggingface.co/docs/transformers/main/en/model_doc/seamless_m4t_v2)
+> or this hands-on [Google Colab](https://colab.research.google.com/github/ylacombe/explanatory_notebooks/blob/main/seamless_m4t_hugging_face.ipynb).
+
 ## SeamlessExpressive
 
 SeamlessExpressive is a speech-to-speech translation model that captures certain underexplored aspects of prosody such as speech rate and pauses, while preserving the style of one's voice and high content translation quality.
@@ -131,9 +135,6 @@ cd demo
 pip install -r requirements.txt
 python app.py
 ```
-
-Seamless M4T is also available in the 🤗 Transformers library. For more details, refer to the [SeamlessM4T docs](https://huggingface.co/docs/transformers/main/en/model_doc/seamless_m4t_v2) 
-or this hands-on [Google Colab](https://colab.research.google.com/github/ylacombe/explanatory_notebooks/blob/main/seamless_m4t_hugging_face.ipynb).
 
 # Resources and usage
 ## Model

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ SeamlessM4T models support the tasks of:
 To learn more about the collection of SeamlessM4T models, the approach used in each, their language coverage and their performance, visit the [SeamlessM4T README](docs/m4t/README.md) or [🤗 Model Card](https://huggingface.co/facebook/seamless-m4t-v2-large).
 
 > [!NOTE]
-> Seamless M4T is also available in the 🤗 Transformers library. Visit the [SeamlessM4T README](docs/m4t/README.md#transformers-usage) for more details.
+> Seamless M4T is also available in the 🤗 Transformers library. Visit [this section](docs/m4t/README.md#transformers-usage) for more details.
 
 ## SeamlessExpressive
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ SeamlessM4T models support the tasks of:
 To learn more about the collection of SeamlessM4T models, the approach used in each, their language coverage and their performance, visit the [SeamlessM4T README](docs/m4t/README.md) or [🤗 Model Card](https://huggingface.co/facebook/seamless-m4t-v2-large).
 
 > [!NOTE]
-> Seamless M4T is also available in the 🤗 Transformers library. For more details, refer to the [SeamlessM4T docs](https://huggingface.co/docs/transformers/main/en/model_doc/seamless_m4t_v2)
-> or this hands-on [Google Colab](https://colab.research.google.com/github/ylacombe/explanatory_notebooks/blob/main/seamless_m4t_hugging_face.ipynb).
+> Seamless M4T is also available in the 🤗 Transformers library. Visit the [SeamlessM4T README](docs/m4t/README.md#transformers-usage) for more details.
 
 ## SeamlessExpressive
 


### PR DESCRIPTION
#240 from @sanchit-gandhi has updated the various READMEs with mentions of the use of transformers. However, the mention of transformers in the main README is currently under [the gradio demos section](https://github.com/facebookresearch/seamless_communication?tab=readme-ov-file#running-seamlessm4t--seamlessexpressive-gradio-demos-locally), which doesn't really fit.

This PR moves it to a more relevant section and also updates the hyperlinks to remove redundancy with the M4T readme.

cc @elbayadm, @cndn and @sanchit-gandhi 