### PR TITLE
Fix S2S pipeline edge case error

### DIFF
--- a/src/seamless_communication/streaming/agents/online_text_decoder.py
+++ b/src/seamless_communication/streaming/agents/online_text_decoder.py
@@ -325,10 +325,7 @@ class MMATextDecoderAgent(OnlineTextDecoderAgent):  # type: ignore
         blocked_ngrams = self.get_blocked_ngrams(states.target_indices)
         decoder_features_out = None
 
-        while (
-            len(states.target_indices + pred_indices) < self.max_len(states)
-            and len(pred_indices) < self.max_consecutive_writes
-        ):
+        while True:
             index, prob, decoder_features = self.run_decoder(states, pred_indices)
 
             if decoder_features_out is None:
@@ -359,6 +356,12 @@ class MMATextDecoderAgent(OnlineTextDecoderAgent):  # type: ignore
                 break
 
             if prob < self.decision_threshold and not states.source_finished:
+                break
+
+            if (
+                len(states.target_indices + pred_indices) >= self.max_len(states)
+                or len(pred_indices) >= self.max_consecutive_writes
+            ):
                 break
 
             pred_indices.append(index)


### PR DESCRIPTION
There is a bug in the MMA text decoder agent policy that throws an error is some edge cases, particularly when the generated token size reaches/exceed the `max_len`.

This can be reproduced as follows:
```
...
  File ".../src/seamless_communication/models/unity/length_regulator.py", line 35, in forward
    upsampled_seqs[b, : upsampled_seq_lens[b]] = seqs[b].repeat_interleave(
RuntimeError: repeats must have the same size as input along dim
```

The fix involves moving the while loop stop condition from teh start of the loop to after the decoder pass (but before the token is added to the prediction list).  


Tested that the inference finishes successfully after the fix.