### PR TITLE
save model as fp16

### DIFF
--- a/ggml/examples/unity/model_loader.cpp
+++ b/ggml/examples/unity/model_loader.cpp
@@ -39,18 +39,15 @@ std::int64_t
 model_loader::load_model_weights(fairseq2_model &model, std::ifstream &fin)
 {
     std::int64_t num_tensor = 0;
-    std::int64_t f32_ctx_size = 0;
+    std::int64_t f32_tensor_size = 0;
     fin.read((char*) &num_tensor, sizeof(num_tensor));
-    fin.read((char*) &f32_ctx_size, sizeof(f32_ctx_size));
+    fin.read((char*) &f32_tensor_size, sizeof(f32_tensor_size));
 
     // TODO: it might be interesting to allow the caller to not upcast the weights to float32.
     // Note this require changing the on disk format
     bool as_float32 = true;
-    std::int64_t f16_ctx_size = f32_ctx_size;
-    // fin.read((char*) &f16_ctx_size, sizeof(f16_ctx_size));
-
     struct ggml_init_params params = {
-        /*.mem_size   =*/ as_float32 ? f32_ctx_size : f16_ctx_size,
+        /*.mem_size   =*/ f32_tensor_size + num_tensor * (int64_t)ggml_tensor_overhead(),
         /*.mem_buffer =*/ NULL,
         /*.no_alloc   =*/ false,
     };

--- a/ggml/examples/unity/model_loader.cpp
+++ b/ggml/examples/unity/model_loader.cpp
@@ -40,13 +40,14 @@ model_loader::load_model_weights(fairseq2_model &model, std::ifstream &fin)
 {
     std::int64_t num_tensor = 0;
     std::int64_t f32_ctx_size = 0;
-    std::int64_t f16_ctx_size = 0;
     fin.read((char*) &num_tensor, sizeof(num_tensor));
     fin.read((char*) &f32_ctx_size, sizeof(f32_ctx_size));
-    fin.read((char*) &f16_ctx_size, sizeof(f16_ctx_size));
 
-    // TODO: it might be intersting to allow the caller to not upcast the weights to float32.
+    // TODO: it might be interesting to allow the caller to not upcast the weights to float32.
+    // Note this require changing the on disk format
     bool as_float32 = true;
+    std::int64_t f16_ctx_size = f32_ctx_size;
+    // fin.read((char*) &f16_ctx_size, sizeof(f16_ctx_size));
 
     struct ggml_init_params params = {
         /*.mem_size   =*/ as_float32 ? f32_ctx_size : f16_ctx_size,

--- a/ggml/examples/unity/model_loader.h
+++ b/ggml/examples/unity/model_loader.h
@@ -30,7 +30,7 @@ private:
     std::string get_name(std::ifstream &fin);
 };
 
-ggml_tensor* load_tensor_value(std::ifstream &fin, ggml_context* ctx);
+ggml_tensor* load_tensor_value(std::ifstream &fin, ggml_context* ctx, bool as_float32);
 
 std::ifstream open_ggml_file(const char* fname);
 

--- a/ggml/ggml_convert.py
+++ b/ggml/ggml_convert.py
@@ -235,7 +235,9 @@ def write_state_dict(
     compressed_byte_size += ggml.ggml_tensor_overhead() * (len(state_dict) + 10)
 
     out.write(struct.pack("<q", true_byte_size))
-    out.write(struct.pack("<q", compressed_byte_size))
+    # TODO: it could be interesting to write this to allow model_loader to chose the precision when loading.
+    # But changing this require republishing .ggml files
+    # out.write(struct.pack("<q", compressed_byte_size))
     GB = 1024**3
     if fp16:
         log.warning(

--- a/ggml/test_unity_cpp.py
+++ b/ggml/test_unity_cpp.py
@@ -100,7 +100,7 @@ def test_convert_linear(tmp_path: Path) -> None:
     layer_config = read_layer_config(module)
     assert layer_config == {"input_dim": 16, "output_dim": 24}
 
-    module_file = Path("module.ggml")
+    module_file = tmp_path / "module.ggml"
     convert_model(module, module_file)
     g_module = ggml.load_fairseq2_ggml_file(module_file)
 
@@ -108,6 +108,28 @@ def test_convert_linear(tmp_path: Path) -> None:
         assert (
             ggml.fairseq2_model_layer_config_int(g_module.ptr, bytes(k, "ascii")) == v
         )
+
+def test_convert_linear_fp16(tmp_path: Path, ctx: Ctx) -> None:
+    pt_model = torch.nn.ModuleDict({"linear": fairseq2.nn.Linear(16, 24, True)})
+
+    layer_config = read_layer_config(pt_model)
+    assert layer_config == {"linear.input_dim": 16, "linear.output_dim": 24}
+
+    ggml_file = tmp_path / "linear.ggml"
+    convert_model(pt_model, ggml_file, fp16=True)
+    assert ggml_file.stat().st_size < (16 * 24 + 24) * 2 * 1.5
+    g_model = ggml.load_fairseq2_ggml_file(ggml_file)
+    ggml.lib.fairseq2_model_set_inference_ctx(g_model.ptr, ctx)
+
+    x = torch.empty((2, 5, 16))
+    torch.nn.init.uniform_(x, -1, 1)
+    y_exp = pt_model.linear(x).numpy()
+    gx = ggml.from_numpy(ctx, x)
+    gy = ggml.forward("Linear", g_model.ptr, "linear", gx)
+    ggml.build_and_compute(ctx, gy)
+    y = ggml.to_numpy(gy)
+
+    assert np.allclose(y_exp, y, atol=1e-3)
 
 
 def test_causal_attention_mask(ctx: Ctx):


### PR DESCRIPTION
Following a user request, I'm adding the `--fp16` flag to `ggml_convert.py` to save the model in half precision.
This helps keep the model on disk size small.

Currently `model_loader.cpp` will automatically upcast `float16` tensors to `float32` , but we could expose a flag to allow keeping the weights in fp16.

I've had to change my first version of the PR because I didn't realized we published `.ggml` artifact, and we would have needed to re-upload them.

I've also added the `--layer_filter` flag to `ggml_convert.py` to remove uneeded layer.
Example usage:

```
python ggml_convert.py -m seamlessM4T_medium --fp16 --layers '^(speech_encoder|text_decoder|final_proj)' -o seamlessM4T_medium_s2t.fp16.ggml

sing the cached checkpoint of seamlessM4T_medium. Set `force` to `True` to download again.
Using the cached tokenizer of seamlessM4T_medium. Set `force` to `True` to download again.
Skipping layer config target_vocab_info=VocabularyInfo(size=256206, unk_idx=1, bos_idx=2, eos_idx=3, pad_idx=0)
Skipping layer config self_attn_mask_factory=CausalAttentionMaskFactory()
WARNING:root:Skipping config for key w2v2_encoder_config__feature_extractor_layer_descs=[]
WARNING:root:Skipping config for key w2v2_encoder_config__pos_encoder_type='relative'
WARNING:ggml_convert:Saving a ggml file with 796 tensors, totalling 4.072Gb compressed to 2.036
```

which reduces the size of seamlessM4T_medium from 6Gb to 2Gb. 