### PR TITLE
torch.compile + CUDA Graph optimization for bs=1

### DIFF
--- a/src/seamless_communication/models/unity/model.py
+++ b/src/seamless_communication/models/unity/model.py
@@ -238,18 +238,33 @@ class UnitYX2TModel(EncoderDecoderModel):
         encoder_padding_mask: Optional[PaddingMask],
         *,
         state_bag: Optional[IncrementalStateBag] = None,
+        cuda_graph_mask: Optional[Tensor] = None,
+        valid_seq_pos: Optional[Tensor] = None,
+        compiled_decoder = None,
     ) -> Tuple[Tensor, Optional[PaddingMask]]:
         seqs, padding_mask = self.decoder_frontend(
             seqs, padding_mask, state_bag=state_bag
         )
-
-        return self.decoder(  # type: ignore[no-any-return]
-            seqs,
-            padding_mask,
-            encoder_output,
-            encoder_padding_mask,
-            state_bag=state_bag,
-        )
+        if compiled_decoder is not None:
+            return compiled_decoder(  # type: ignore[no-any-return]
+                seqs,
+                padding_mask,
+                encoder_output,
+                encoder_padding_mask,
+                state_bag=state_bag,
+                cuda_graph_mask=cuda_graph_mask,
+                valid_seq_pos=valid_seq_pos,
+            )
+        else:
+            return self.decoder(  # type: ignore[no-any-return]
+                seqs,
+                padding_mask,
+                encoder_output,
+                encoder_padding_mask,
+                state_bag=state_bag,
+                cuda_graph_mask=cuda_graph_mask,
+                valid_seq_pos=valid_seq_pos,
+            )
 
     @finaloverride
     def project(
@@ -428,7 +443,7 @@ class UnitYNART2UModel(Module):
             duration_factor,
             film_cond_emb,
         )
-
+        
         seqs, padding_mask = self.decoder(
             seqs, padding_mask, film_cond_emb=film_cond_emb
         )


### PR DESCRIPTION
PR request for Pytorch blog post.

Summary:
This post is the fourth part of a multi-series blog focused on how to accelerate generative AI models with pure, native PyTorch.  In this blog, we’ll focus on speeding up **FAIR’s Seamless M4T-v2** model resulting in 2x speedup for text decoder module and 30x for vocoder module, resulting in 2.7x speedup for end-to-end inference, with no loss of accuracy by using CUDA Graph and native PyTorch optimization: torch.compile.

![End-to-end Inference Speedup](https://github.com/facebookresearch/seamless_communication/assets/28900943/cf8231b2-1df3-415a-b1ee-218bb8e53c4d)
