### PR TITLE
Enable using `m4t_evaluate` with a Manifest JSON file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# JetBrains PyCharm IDE
+# Editors
 .idea/
+.vscode/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/src/seamless_communication/cli/m4t/evaluate/evaluate.py
+++ b/src/seamless_communication/cli/m4t/evaluate/evaluate.py
@@ -393,7 +393,7 @@ def main(optional_args: Optional[Dict[str, Any]] = None) -> None:
     default_args.update(optional_args) if optional_args else default_args
     args = Namespace(**default_args)
 
-    assert args.data_file and args.task and args.tgt_lang, \
+    assert args.data_file and args.task and args.tgt_lang and args.output_path, \
         "Please provide required arguments for evaluation - data_file, task, tgt_lang"
         
     assert Path(args.data_file).exists(), \

--- a/src/seamless_communication/cli/m4t/evaluate/evaluate.py
+++ b/src/seamless_communication/cli/m4t/evaluate/evaluate.py
@@ -9,6 +9,7 @@ import contextlib
 import itertools
 import logging
 import subprocess
+import json
 from argparse import Namespace
 from dataclasses import dataclass
 from pathlib import Path
@@ -63,7 +64,10 @@ class EvalContext:
     """The name of the S2T UnitY model."""
 
     data_file: Path
-    """The pathname of the test TSV data file."""
+    """The pathname of the test data file, TSV or manifest JSON."""
+    
+    data_file_type: str
+    """Type of data file, TSV or manifest JSON."""
 
     audio_root_dir: Optional[Path]
     """The pathname of the directory under which
@@ -113,17 +117,36 @@ def build_data_pipeline(
     ctx: EvalContext,
     text_tokenizer: TextTokenizer,
 ) -> DataPipeline:
-    with open(ctx.data_file, "r") as f:
-        header = f.readline().strip("\n").split("\t")
-        first_example = f.readline().strip("\n").split("\t")
+    
+    if ctx.data_file_type == "TSV":
+        with open(ctx.data_file, "r") as f:
+            header = f.readline().strip("\n").split("\t")
+            first_example = f.readline().strip("\n").split("\t")
+
+        format_tsv = StrSplitter(names=header)
+        pipeline_builder = read_text(ctx.data_file, rtrim=True).skip(1).map(format_tsv)
+        
+    elif ctx.data_file_type == "JSON":
+        def format_json(line: str):
+            example = json.loads(line)
+            return {
+                "src_text": example["source"]["text"],
+                "src_lang": example["source"]["lang"],
+                "audio": example["source"]["audio_local_path"],
+                "ref_tgt_text": example["target"]["text"],
+            }
+        
+        with open(ctx.data_file, "r") as f:
+            header = list(format_json(f.readline()).keys())
+            first_example = list(format_json(f.readline()).values())
+            
+        pipeline_builder = read_text(ctx.data_file, rtrim=True).map(format_json)
+        
+    else:
+        raise NotImplementedError
 
     # TODO: This will be soon auto-tuned. Right now hand-tuned for devfair.
     n_parallel = 4
-
-    split_tsv = StrSplitter(names=header)
-
-    pipeline_builder = read_text(ctx.data_file, rtrim=True).skip(1).map(split_tsv)
-
     if ctx.input_modality == Modality.SPEECH:
         assert ctx.audio_root_dir is not None
 
@@ -334,7 +357,10 @@ def main(optional_args: Optional[Dict[str, Any]] = None) -> None:
         description="M4T evaluation for tasks supported by Translator."
     )
     parser.add_argument(
-        "--data_file", type=str, help="Data file (.tsv) to be evaluated."
+        "--data_file", 
+        type=str, 
+        help="Data file to be evaluated, either TSV file or manifest JSON file."
+        "Format of the manifest JSON file should be that as produced by `m4t_prepare_dataset`"
     )
 
     parser = add_inference_arguments(parser)
@@ -367,14 +393,19 @@ def main(optional_args: Optional[Dict[str, Any]] = None) -> None:
     default_args.update(optional_args) if optional_args else default_args
     args = Namespace(**default_args)
 
-    if not args.data_file or not args.task or not args.tgt_lang:
-        raise Exception(
-            "Please provide required arguments for evaluation - data_file, task, tgt_lang"
-        )
-
-    if not Path(args.data_file).exists():
-        raise ValueError(f"Invalid data_file to be evaluated: {args.data_file}")
-
+    assert args.data_file and args.task and args.tgt_lang, \
+        "Please provide required arguments for evaluation - data_file, task, tgt_lang"
+        
+    # assert Path(args.data_file).exists(), \
+    #     f"Invalid `data_file`: {args.data_file} does not exist"
+        
+    if Path(args.data_file).suffix == ".tsv":
+        data_type = "TSV"
+    elif Path(args.data_file).suffix == ".json":
+        data_type = "JSON"
+    else:
+        raise ValueError("Unable to recognize file type! Please use a data_file with either .tsv or .json extension.")
+    
     input_modality, output_modality = Translator.get_modalities_from_task_str(args.task)
 
     if input_modality == Modality.SPEECH and not Path(args.audio_root_dir).exists():
@@ -418,6 +449,7 @@ def main(optional_args: Optional[Dict[str, Any]] = None) -> None:
         output_modality=output_modality,
         model_name=args.model_name,
         data_file=Path(args.data_file),
+        data_file_type=data_type,
         audio_root_dir=Path(args.audio_root_dir),
         target_lang=args.tgt_lang,
         source_lang=args.src_lang,

--- a/src/seamless_communication/cli/m4t/evaluate/evaluate.py
+++ b/src/seamless_communication/cli/m4t/evaluate/evaluate.py
@@ -128,12 +128,12 @@ def build_data_pipeline(
         
     elif ctx.data_file_type == "JSON":
         def format_json(line: str):
-            example = json.loads(line)
+            example = json.loads(str(line))
             return {
                 "src_text": example["source"]["text"],
                 "src_lang": example["source"]["lang"],
                 "audio": example["source"]["audio_local_path"],
-                "ref_tgt_text": example["target"]["text"],
+                "tgt_text": example["target"]["text"],
             }
         
         with open(ctx.data_file, "r") as f:

--- a/src/seamless_communication/cli/m4t/evaluate/evaluate.py
+++ b/src/seamless_communication/cli/m4t/evaluate/evaluate.py
@@ -396,8 +396,8 @@ def main(optional_args: Optional[Dict[str, Any]] = None) -> None:
     assert args.data_file and args.task and args.tgt_lang, \
         "Please provide required arguments for evaluation - data_file, task, tgt_lang"
         
-    # assert Path(args.data_file).exists(), \
-    #     f"Invalid `data_file`: {args.data_file} does not exist"
+    assert Path(args.data_file).exists(), \
+        f"Invalid `data_file`: {args.data_file} does not exist"
         
     if Path(args.data_file).suffix == ".tsv":
         data_type = "TSV"

--- a/src/seamless_communication/cli/m4t/predict/predict.py
+++ b/src/seamless_communication/cli/m4t/predict/predict.py
@@ -24,7 +24,16 @@ logger = logging.getLogger(__name__)
 
 
 def add_inference_arguments(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-    parser.add_argument("--task", type=str, help="Task type")
+    parser.add_argument(
+        "--task", 
+        type=str, 
+        choices=["ASR", "S2ST", "S2TT"],
+        help=(
+            "* `ASR` -- automatic speech recognition (transcription);"
+            "* `S2ST` -- speech to speech translation;"
+            "* `S2TT` -- speech to text translation;"
+        )
+    )
     parser.add_argument(
         "--tgt_lang", type=str, help="Target language to translate/transcribe into."
     )


### PR DESCRIPTION
The problem I had with `m4t_evaluate` is that the inputs it expects are different from those of `m4t_finetune` and what `m4t_prepare_dataset` generates. Evaluate expects a TSV file and directories while both the others work with a manifest JSON file.

I have changed the `m4t_evaluate` to accept the same inputs as the other two, i.e. a manifest JSON file.

The `--data_file` input can now be either a TSV path or a manifest path.
Also, `--output_path` is now required because the CLI fails otherwise.


<details>
<summary>Here is a sample run with just 3 lines in a manifest JSON file</summary>
<pre>▶ m4t_evaluate --data_file build/fleurs/test_manifest_1.json --task ASR --tgt_lang eng --output_path build/fleurs
Using the cached tokenizer of seamlessM4T_v2_large. Set `force` to `True` to download again.
Using the cached checkpoint of seamlessM4T_v2_large. Set `force` to `True` to download again.
2024-03-27 03:11:10,791 INFO -- seamless_communication.cli.m4t.evaluate.evaluate: text_generation_opts=SequenceGeneratorOptions(beam_size=5, soft_max_seq_len=(1, 200), hard_max_seq_len=1024, step_processor=None, unk_penalty=0.0, len_penalty=1.0)
2024-03-27 03:11:10,797 INFO -- seamless_communication.cli.m4t.evaluate.evaluate: unit_generation_opts=SequenceGeneratorOptions(beam_size=5, soft_max_seq_len=(25, 50), hard_max_seq_len=1024, step_processor=None, unk_penalty=0.0, len_penalty=1.0)
2024-03-27 03:11:10,797 INFO -- seamless_communication.cli.m4t.evaluate.evaluate: unit_generation_ngram_filtering=False
2024-03-27 03:11:10,801 INFO -- seamless_communication.cli.m4t.evaluate.evaluate: Running inference on device=device(type='cpu') with dtype=torch.float32, ctx.batch_size=4.
3it [00:26,  8.73s/it]                                                                                                                                                                        
2024-03-27 03:11:37,123 INFO -- seamless_communication.cli.m4t.evaluate.evaluate: Processed 3 samples
2024-03-27 03:11:37,156 INFO -- seamless_communication.cli.eval_utils.compute_metrics: ASR : {
 "name": "WER",
 "score": 0.16666666666666666,
 "signature": "wer is 0.16666666666666666"
}</pre>
</details>