### PR TITLE
Added Spanish langcode mapping

### DIFF
--- a/src/seamless_communication/cli/m4t/finetune/dataset.py
+++ b/src/seamless_communication/cli/m4t/finetune/dataset.py
@@ -72,6 +72,7 @@ UNITY_TO_FLEURS_LANG_MAPPING = {
     "rus": "ru_ru",
     "snd": "sd_in",
     "slk": "sk_sk",
+    "spa": "es_419",
     "srp": "sr_rs",
     "swh": "sw_ke",
     "tam": "ta_in",


### PR DESCRIPTION
I got this error while downloading Fleurs dataset for Spanish.
```
$ m4t_prepare_dataset --source_lang spa --target_lang spa ...
ValueError: No language code mapping for spa(M4T)->??(FLEURs). Please expand `UNITY_TO_FLEURS_LANG_MAPPING`
```

And I've fixed this here. `spa(M4T) -> es_419(FLEURs)`
