### PR TITLE
Fix float precision in Finetune CLI

### DIFF
--- a/src/seamless_communication/cli/m4t/finetune/finetune.py
+++ b/src/seamless_communication/cli/m4t/finetune/finetune.py
@@ -126,7 +126,7 @@ def main() -> None:
     args = init_parser().parse_args()
     dist_utils.init_distributed([logger, trainer.logger])
     device = torch.device("cuda")
-    float_dtype = torch.float16
+    float_dtype = torch.float32
     text_tokenizer: NllbTokenizer = load_unity_text_tokenizer(args.model_name)
     unit_tokenizer: UnitTokenizer = load_unity_unit_tokenizer(args.model_name)
     finetune_params = trainer.FinetuneParams(


### PR DESCRIPTION
The finetune CLI would load the model in float16 and then attempt to train. Doing it this was, the model would unable to converge. Here the model is loaded in float32 and then we allow autocasting where it is needed.