### PR TITLE
Indicate the SONAR device in the mutox example

### DIFF
--- a/src/seamless_communication/cli/toxicity/mutox/mutox_example.ipynb
+++ b/src/seamless_communication/cli/toxicity/mutox/mutox_example.ipynb
@@ -180,6 +180,7 @@
     "t2vec_model = TextToEmbeddingModelPipeline(\n",
     "    encoder=\"text_sonar_basic_encoder\",\n",
     "    tokenizer=\"text_sonar_basic_encoder\",\n",
+    "    device=device,\n",
     ")\n",
     "text_column='lang_txt'\n",
     "classifier = load_mutox_model(\n",


### PR DESCRIPTION
**Why**

I heard complaints from external users that MUTOX is slow. And it was just because they didn't know that SONAR encoder by default loads to CPU. 

**How**
I pass `device` to the SONAR encoder constructor in our example notebook, so that if there is a GPU, it is used.