### PR TITLE
Fixed finetuning trainer and enable freezing layers

### DIFF
--- a/src/seamless_communication/cli/m4t/finetune/dataloader.py
+++ b/src/seamless_communication/cli/m4t/finetune/dataloader.py
@@ -191,6 +191,7 @@ class UnitYDataLoader:
         return torch.stack([tensor for tensor in padded_tensors], dim=0)
 
     def _is_long_src_audio(self, sample: LangPairSample) -> bool:
+        # HACK:: causes errored audios to be excluded but this is difficult to follow
         try:
             wav, sample_rate = torchaudio.load(sample.source.audio_local_path)
             length_s: float = max(wav.shape) / sample_rate

--- a/src/seamless_communication/cli/m4t/finetune/dataloader.py
+++ b/src/seamless_communication/cli/m4t/finetune/dataloader.py
@@ -197,6 +197,7 @@ class UnitYDataLoader:
             length_s: float = max(wav.shape) / sample_rate
             return length_s > self.batching_config.max_audio_length_sec
         except:
+            logger.exception(f"Failed to load sample path: {sample.source.audio_local_path}")
             return True
 
     def _prepare_batch(self, raw_samples: List[Dict[str, Any]]) -> MultimodalSeqsBatch:

--- a/src/seamless_communication/cli/m4t/finetune/finetune.py
+++ b/src/seamless_communication/cli/m4t/finetune/finetune.py
@@ -117,11 +117,12 @@ def init_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
-        "--freeze",
+        "--freeze_layers",
         nargs="*",
         required=False,
+        default=None,
         # TODO: better description
-        help=("A list of modules to freeze in the model"),
+        help=("A list of modules to freeze in the model. If empty, everything will be trained."),
     )
     parser.add_argument(
         "--device",
@@ -205,7 +206,7 @@ def main() -> None:
         params=finetune_params,
         train_data_loader=train_dataloader,
         eval_data_loader=eval_dataloader,
-        freeze_modules=args.freeze
+        freeze_modules=args.freeze_layers
     )
     
     finetune.run()

--- a/src/seamless_communication/cli/m4t/finetune/finetune.py
+++ b/src/seamless_communication/cli/m4t/finetune/finetune.py
@@ -157,11 +157,10 @@ def main() -> None:
         eval_steps=args.eval_steps,
         log_steps=args.log_steps,
     )
+    
     logger.info(f"Finetune Params: {finetune_params}")
     
-    model = load_unity_model(
-        args.model_name, device=torch.device("cpu"), dtype=torch.float32
-    )
+    model = load_unity_model(args.model_name, device=torch.device("cpu"), dtype=torch.float32)
     assert model.target_vocab_info == text_tokenizer.vocab_info
     
     if (
@@ -187,8 +186,8 @@ def main() -> None:
             max_audio_length_sec=15.0,
             float_dtype=finetune_params.float_dtype,
         ),
-        dataset_manifest_path=args.train_dataset,
-    )
+        dataset_manifest_path=args.train_dataset)
+    
     eval_dataloader = dataloader.UnitYDataLoader(
         text_tokenizer=text_tokenizer,
         unit_tokenizer=unit_tokenizer,
@@ -199,15 +198,14 @@ def main() -> None:
             max_audio_length_sec=75.0,
             float_dtype=finetune_params.float_dtype,
         ),
-        dataset_manifest_path=args.eval_dataset,
-    )
+        dataset_manifest_path=args.eval_dataset)
+    
     finetune = trainer.UnitYFinetune(
         model=model,
         params=finetune_params,
         train_data_loader=train_dataloader,
         eval_data_loader=eval_dataloader,
-        freeze_modules=args.freeze_layers
-    )
+        freeze_modules=args.freeze_layers)
     
     finetune.run()
 

--- a/src/seamless_communication/cli/m4t/finetune/finetune.py
+++ b/src/seamless_communication/cli/m4t/finetune/finetune.py
@@ -170,7 +170,7 @@ def main() -> None:
         model.text_encoder = None
     
     model = model.to(finetune_params.device)
-    logger.info(f"<{args.model_name}> {model}")
+    # logger.debug(f"<{args.model_name}> {model}")
 
     train_dataloader = dataloader.UnitYDataLoader(
         text_tokenizer=text_tokenizer,

--- a/src/seamless_communication/cli/m4t/finetune/finetune.py
+++ b/src/seamless_communication/cli/m4t/finetune/finetune.py
@@ -85,6 +85,12 @@ def init_parser() -> argparse.ArgumentParser:
         help=("Max number of training epochs"),
     )
     parser.add_argument(
+        "--max_batches",
+        type=int,
+        default=None,
+        help=("Max number of training batches"),
+    )
+    parser.add_argument(
         "--learning_rate",
         type=float,
         default=1e-7,
@@ -191,7 +197,7 @@ def main() -> None:
             batch_size=finetune_params.eval_batch_size,
             rank=dist_utils.get_rank(),
             world_size=dist_utils.get_world_size(),
-            max_audio_length_sec=100.0,
+            max_audio_length_sec=75.0,
             float_dtype=finetune_params.float_dtype,
         ),
         dataset_manifest_path=args.eval_dataset,
@@ -200,9 +206,10 @@ def main() -> None:
         model=model,
         params=finetune_params,
         train_data_loader=train_dataloader,
-        eval_data_loader=eval_dataloader,
+        eval_data_loader=eval_dataloader
     )
-    finetune.run()
+    
+    finetune.run(stop_at=args.max_batches)
 
 
 if __name__ == "__main__":

--- a/src/seamless_communication/cli/m4t/finetune/finetune.py
+++ b/src/seamless_communication/cli/m4t/finetune/finetune.py
@@ -132,8 +132,7 @@ def main() -> None:
     args = init_parser().parse_args()
     
     dist_utils.init_distributed([logger, trainer.logger])
-    device = torch.device("cuda")
-    float_dtype = torch.float16
+    float_dtype = torch.float16 if torch.device(args.device).type != "cpu" else torch.bfloat16
     
     text_tokenizer: NllbTokenizer = load_unity_text_tokenizer(args.model_name)
     unit_tokenizer: UnitTokenizer = load_unity_unit_tokenizer(args.model_name)
@@ -143,7 +142,7 @@ def main() -> None:
         finetune_mode=args.mode,
         save_model_path=args.save_model_to,
         device=torch.device(args.device),
-        float_dtype=torch.float16 if torch.device(args.device).type != "cpu" else torch.bfloat16,
+        float_dtype=float_dtype,
         train_batch_size=args.batch_size,
         eval_batch_size=args.batch_size,
         patience=args.patience,
@@ -159,7 +158,7 @@ def main() -> None:
     )
     
     assert model.target_vocab_info == text_tokenizer.vocab_info
-    # (optional) delete unused params to reduce GPU memory consumption
+    # TODO: delete unused params to reduce GPU memory consumption
     
     if (
         finetune_params.finetune_mode == trainer.FinetuneMode.SPEECH_TO_TEXT

--- a/src/seamless_communication/cli/m4t/finetune/trainer.py
+++ b/src/seamless_communication/cli/m4t/finetune/trainer.py
@@ -40,6 +40,9 @@ class FinetuneMode(Enum):
 
 @dataclass
 class FinetuneParams:
+    model_name: str
+    """Model name of model being finetuned."""
+    
     save_model_path: Path
     """Path were to save finetuned model."""
 
@@ -372,11 +375,13 @@ class UnitYFinetune:
     def _save_model(self) -> None:
         logger.info("Saving model")
         if dist_utils.is_main_process():
-            state_dict = {
-                key.replace("module.model.", ""): value
-                for key, value in self.model.state_dict().items()
-            }
-            torch.save(state_dict, self.params.save_model_path)
+            torch.save({
+                "model_name": self.params.model_name,
+                "model": {
+                    key.replace("module.model.", ""): value
+                    for key, value in self.model.state_dict().items()
+                }
+            }, self.params.save_model_path)
         if dist_utils.is_dist_initialized():
             dist.barrier()
 

--- a/src/seamless_communication/cli/m4t/finetune/trainer.py
+++ b/src/seamless_communication/cli/m4t/finetune/trainer.py
@@ -249,7 +249,7 @@ class UnitYFinetune:
         params: FinetuneParams,
         train_data_loader: dataloader.UnitYDataLoader,
         eval_data_loader: Optional[dataloader.UnitYDataLoader] = None,
-        freeze_modules: Optional[List[Union[str, torch.nn.Module]]] = None,
+        freeze_modules: Optional[List[Union[str, torch.nn.Module]]] = None
     ):
         self.params = params
         self.calc_loss = CalcLoss(
@@ -312,17 +312,13 @@ class UnitYFinetune:
             find_unused_parameters=find_unused,
         )
         
-    def _freeze_modules(self, frozen_modules: List[Union[str, torch.nn.Module]]) -> None:
+    def _freeze_modules(self, frozen_modules: List[str] = []) -> None:
         for icecube in frozen_modules:
-            if type(icecube) == torch.nn.Module:
-                for param in icecube.parameters():
-                    param.requires_grad = False
-            if type(icecube) == str:
-                for (name, module) in self.model.named_modules():
-                    if name.startswith(icecube):
-                        print(name)
-                        for param in module.parameters():
-                            param.requires_grad = False
+            for (name, module) in self.model.named_modules():
+                if name.startswith(icecube):
+                    logger.info(f"Freezing Module: {name}")
+                    for param in module.parameters():
+                        param.requires_grad = False
 
     def _update_eval_stats(self, eval_loss: float) -> None:
         self.is_best_state = (

--- a/src/seamless_communication/datasets/huggingface.py
+++ b/src/seamless_communication/datasets/huggingface.py
@@ -28,7 +28,7 @@ class SpeechTokenizer:
 class Speech2SpeechFleursDatasetBuilder:
     """Assembles speech2speech dataset from google/fleurs on HuggingFace"""
 
-    HF_FLEURS_DATASET_NAME = "google/fleurs"
+    DATASET_NAME = "google/fleurs"
 
     def __init__(
         self,
@@ -91,7 +91,113 @@ class Speech2SpeechFleursDatasetBuilder:
 
     def iterate_lang_audio_samples(self, lang: str) -> Iterable[MultimodalSample]:
         ds = load_dataset(
-            self.HF_FLEURS_DATASET_NAME,
+            self.DATASET_NAME,
+            lang,
+            split=self.split,
+            cache_dir=self.dataset_cache_dir,
+            streaming=False,
+            trust_remote_code=True,
+        )
+        for item in ds:
+            audio_path = os.path.join(
+                os.path.dirname(item["path"]), item["audio"]["path"]
+            )
+            (sample_id, audio_local_path, waveform, sampling_rate, text) = (
+                item["id"],
+                audio_path,
+                item["audio"]["array"],
+                item["audio"]["sampling_rate"],
+                item["transcription"],
+            )
+            yield self._prepare_sample(
+                sample_id=sample_id,
+                audio_local_path=audio_local_path,
+                waveform_npy=waveform,
+                sampling_rate=sampling_rate,
+                text=text,
+                lang=lang,
+            )
+
+    def __iter__(self) -> Iterable[LangPairSample]:
+        logger.info(f"Loading {self.target_lang} samples")
+        target_samples: Dict[int, MultimodalSample] = {}
+        for idx, sample in enumerate(
+            self.iterate_lang_audio_samples(lang=self.target_lang)
+        ):
+            if idx and idx % 100 == 0:
+                logger.info(f"..loaded {idx} target samples")
+            target_samples[sample.id] = sample
+
+        logger.info(f"Loading {self.source_lang} samples")
+        for idx, sample in enumerate(
+            self.iterate_lang_audio_samples(lang=self.source_lang)
+        ):
+            if idx and idx % 100 == 0:
+                logger.info(f"..loaded {idx} source samples")
+            if sample.id in target_samples:
+                yield LangPairSample(source=sample, target=target_samples[sample.id])
+
+
+class Speech2TextGigaspeechDatasetBuilder:
+    """ Assembles speech2speech dataset from google/fleurs on HuggingFace.
+        This dataset requires signing an license agreement and using an auth token.
+    """
+
+    DATASET_NAME = "speechcolab/gigaspeech"
+
+    def __init__(
+        self,
+        auth_token: str,
+        split: str = "test",
+        skip_source_audio: bool = True,
+        skip_target_audio: bool = True,
+        audio_dtype: torch.dtype = torch.float32,
+        dataset_cache_dir: Optional[str] = None,
+        speech_tokenizer: Optional[SpeechTokenizer] = None,
+    ):
+        self.auth_token = auth_token
+        self.split = split
+        self.dataset_cache_dir = dataset_cache_dir
+        self.audio_dtype = audio_dtype
+        self.skip_source_audio = skip_source_audio
+        self.skip_target_audio = skip_target_audio
+        self.speech_tokenizer = speech_tokenizer
+
+    def _prepare_sample(
+        self,
+        sample_id: int,
+        lang: str,
+        text: str,
+        audio_local_path: Optional[str] = None,
+        waveform_npy: Optional[np.ndarray] = None,
+        sampling_rate: Optional[int] = None,
+    ) -> MultimodalSample:
+        if waveform_npy is not None:
+            waveform = torch.from_numpy(waveform_npy).to(self.audio_dtype)
+        else:
+            waveform = None
+        if self.speech_tokenizer is not None and waveform_npy is not None:
+            assert waveform is not None
+            assert sampling_rate is not None
+            units_tensor = self.speech_tokenizer.encode(
+                waveform, sampling_rate
+            ).reshape(-1)
+            units = units_tensor.tolist()
+        else:
+            units = None
+        return MultimodalSample(
+            id=sample_id,
+            lang=lang,
+            text=text.strip(),
+            audio_local_path=audio_local_path,
+            waveform=waveform,
+            sampling_rate=sampling_rate,
+            units=units,
+        )
+
+    def iterate_lang_audio_samples(self, lang: str) -> Iterable[MultimodalSample]:
+        ds = load_dataset(
+            self.DATASET_NAME,
             lang,
             split=self.split,
             cache_dir=self.dataset_cache_dir,


### PR DESCRIPTION
This fixes some issues with M4T finetuning CLI and enables freezing parts of a model before training

**Example:**
```
m4t_finetune \
  --train_dataset gigaspeech/xs/xs_train_manifest.json \
  --eval_dataset gigaspeech/xs/xs_validation_manifest.json \
  --batch_size 10 \
  --eval_steps 1000 \
  --learning_rate 0.00008 \
  --patience 10 \
  --save_model_to checkpoints/expt5_m4tM.pt \
  --model_name seamlessM4T_medium \
  --freeze_layers \
      model.speech_encoder_frontend \
      model.speech_encoder \
      model.text_encoder_frontend \
      model.text_decoder.layers.0 \
      model.text_decoder.layers.1 \
      model.text_decoder.layers.2
```