### PR TITLE
Enable downloading Gigaspeech

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     url="https://github.com/facebookresearch/seamless_communication",
     license="Creative Commons",
     install_requires=[
-        "datasets",
+        "datasets==2.18.0",
         "fairseq2==0.2.*",
         "fire",
         "librosa",

--- a/src/seamless_communication/cli/m4t/finetune/dataset.py
+++ b/src/seamless_communication/cli/m4t/finetune/dataset.py
@@ -190,6 +190,12 @@ def init_parser() -> argparse.ArgumentParser:
         )
     )
     parser.add_argument(
+        "--name",
+        type=str,
+        required=True,
+        help="HuggingFace name of the dataset to prepare.",
+    )
+    parser.add_argument(
         "--source_lang",
         type=str,
         required=True,

--- a/src/seamless_communication/cli/m4t/finetune/dataset.py
+++ b/src/seamless_communication/cli/m4t/finetune/dataset.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 from pathlib import Path
+from tqdm import tqdm
 
 import torch
 
@@ -159,9 +160,10 @@ def download_fleurs(
 def download_gigaspeech(subset: str, huggingface_token: str, save_directory: str):
     ds = load_dataset("speechcolab/gigaspeech", subset, cache_dir=f"gigaspeech/{subset}", token=huggingface_token)
     for split in ds:
-        manifest_path = os.path.join(save_directory, subset, f"{subset}_{split}_manifest.json")
+        manifest_path = os.path.join(save_directory, f"{subset}_{split}_manifest.json")
+        logger.info(f"Preparing {split} split...")
         with open(manifest_path, "w") as f:
-            for sample in ds[split]:
+            for sample in tqdm(ds[split]):
                 f.write(json.dumps({
                 "source": {
                     "id": sample["segment_id"],


### PR DESCRIPTION
It is now possible to download another dataset, other than Google Fleurs. It is necessary to first [sign the Gigaspeech agreement](https://huggingface.co/datasets/speechcolab/gigaspeech) and get access to the dataset, then [create a Huggingface token](https://huggingface.co/docs/hub/en/security-tokens) and to use this while calling the CLI.

```
m4t_prepare_dataset \
  --name speechcolab/gigaspeech \
  --split xs \
  --source_lang eng \
  --target_lang eng \
  --save_dir gigaspeech/xs \
  --huggingface_token <TOKEN>
```