### PR TITLE
Use weights_only for load

### DIFF
--- a/src/seamless_communication/cli/m4t/evaluate/evaluate.py
+++ b/src/seamless_communication/cli/m4t/evaluate/evaluate.py
@@ -363,7 +363,7 @@ def run_eval(
 
 
 def load_checkpoint(model: UnitYModel, path: str, device = torch.device("cpu")) -> None:
-    saved_model = torch.load(path, map_location=device)["model"]
+    saved_model = torch.load(path, map_location=device, weights_only=True)["model"]
     saved_model = { k.replace("model.", ""): v for k, v in saved_model.items() }
 
     def _select_keys(state_dict: Dict[str, Any], prefix: str) -> Dict[str, Any]:


### PR DESCRIPTION
`torch.load` without `weights_only` parameter is unsafe. Explicitly set `weights_only` to False only if you trust the data you load and full pickle functionality is needed, otherwise set `weights_only=True`.

If `weights_only=True` doesn't work for some cases, then explicit `weights_only=False` should be used.

Found with https://github.com/pytorch-labs/torchfix/