### PR TITLE
Change device but not dtype in UnitY2AlignmentModel

### DIFF
--- a/src/seamless_communication/models/aligner/model.py
+++ b/src/seamless_communication/models/aligner/model.py
@@ -297,8 +297,8 @@ class UnitY2AlignmentModel(Module):
         attn_lprob, attn_hard_dur = self.alignment_encoder(
             embs_text,
             embs_unit,
-            torch.tensor([embs_text.size(1)]).to(embs_text).int(),
-            torch.tensor([embs_unit.size(1)]).to(embs_unit).int(),
+            torch.tensor([embs_text.size(1)]).to(device=embs_text.device).int(),
+            torch.tensor([embs_unit.size(1)]).to(device=embs_unit.device).int(),
         )
 
         return attn_lprob, attn_hard_dur


### PR DESCRIPTION
When `embs_text.size(1)` or `embs_unit.size(1)` is large and the model's type is `torch.float16`, there are [half-precision issues](https://en.wikipedia.org/wiki/Half-precision_floating-point_format?fbclid=IwZXh0bgNhZW0CMTEAAR12lWXcsM23AP3vH2ky0QGCH_2RPONHjTidU7HAYiXJuh2frW1CVbO_4n0_aem_fbnaH5lE5XNp1nzdvBtcJQ#Precision_limitations). This is easily reproducible locally:
```bash
>>> import torch
>>> torch.tensor([2131]).to(dtype=torch.float16).int()
tensor([2132], dtype=torch.int32)
```
This causes downstream issues, especially [in this line](https://github.com/facebookresearch/seamless_communication/blob/90e2b57ac4d82fa2bfaa25caeffe39ceb8b2ebec/src/seamless_communication/models/aligner/model.py#L179). We got the following error in production:
```bash
score = score.masked_fill(padding_mask, -np.inf)
RuntimeError: The size of tensor a (2136) must match the size of tensor b (2137) at non-singleton dimension 2
```
The following fix aims to make sure that there are no unnecessary `dtype` conversions in the code that could cause these size mismatch issues. We do however make sure that the device is changed if need be.